### PR TITLE
In requirements.txt, pytest was probably mistaken for pytext

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyserial
-pytext
+pytest
 flask8
 black


### PR DESCRIPTION
In requirements.txt, pytest was probably mistaken for pytext
・Changes
I changed "pytext" to "pytest" in the requirements.txt file.






